### PR TITLE
Update to use proper Authorization for new API

### DIFF
--- a/lib/passport-foodlogiq/strategy.js
+++ b/lib/passport-foodlogiq/strategy.js
@@ -22,6 +22,7 @@ util.inherits(Strategy, OAuth2Strategy);
 Strategy.prototype.userProfile = function(accessToken, done) {
   var profileUrl = this.baseURL + '/user';
   
+  this._oauth2.useAuthorizationHeaderforGET(true);
   this._oauth2.get(profileUrl, accessToken, function (err, body, res) {
     if (err) {
       winston.error('failed to fetch user profile with given grant');


### PR DESCRIPTION
Change needed to tell OAuth2 to use "Authorization: Bearer + <AccessToken>" Header which Connect API requires.
